### PR TITLE
added support for https and changed listening port to 443

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ RUN pip install .
 RUN apk del .build-deps
 CMD alembic upgrade head && python -m feeder
 EXPOSE 1883/tcp
-EXPOSE 5000/tcp
+EXPOSE 443/tcp
 EXPOSE 8883/tcp

--- a/README.md
+++ b/README.md
@@ -53,21 +53,18 @@ In this example, I'm assuming you're redirecting to the actual server
 at address `192.168.1.10` from the fake address:
 
 ```
-iptables -t nat -A PREROUTING -i eth0 -p tcp -d 172.4.0.1 --dport 80 -j DNAT --to 192.168.1.10:5000
+iptables -t nat -A PREROUTING -i eth0 -p tcp -d 172.4.0.1 --dport 80 -j DNAT --to 192.168.1.10:443
 iptables -t nat -A PREROUTING -i eth0 -p tcp -d 172.4.0.1 --dport 1883 -j DNAT --to 192.168.1.10:1883
 iptables -t nat -A PREROUTING -i eth0 -p tcp -d 172.4.0.1 --dport 8883 -j DNAT --to 192.168.1.10:8883
 ```
 
-# Running the app
-
-You will need to run some form of SSL proxy (NGINX, Traefik, etc.) in front of this service. 
 
 ## docker
 
 ```
 docker run -d \
   --name=petnet-feeder-service \
-  -p 5000:5000 \
+  -p 443:443 \
   -p 8883:8883 \
   --restart unless-stopped \
   tedder42/petnet-feeder-service
@@ -90,7 +87,7 @@ services:
       # define that path using the APP_ROOT variable.
       # - APP_ROOT=/petnet
     ports:
-      - 5000:5000
+      - 443:443
       - 8883:8883
     volumes:
       - "/local/path:/data"
@@ -101,7 +98,7 @@ services:
 
 | Parameter | Function |
 | :----: | --- |
-| `-p 5000:5000` | The HTTP access port for the webserver. |
+| `-p 443:443` | The HTTPSs access port for the webserver. |
 | `-p 8883:8883` | The MQTT TLS port for the PetNet feeder. |
 
 # Developing

--- a/feeder/__main__.py
+++ b/feeder/__main__.py
@@ -111,4 +111,4 @@ async def shutdown_event():
 
 
 if __name__ == "__main__":
-    uvicorn.run("feeder.__main__:app", host="0.0.0.0", port=settings.http_port)
+        uvicorn.run("feeder.__main__:app", host="0.0.0.0", port=settings.http_port, ssl_keyfile=settings.mqtts_private_key, ssl_certfile = settings.mqtts_public_key)

--- a/feeder/config.py
+++ b/feeder/config.py
@@ -42,5 +42,5 @@ class Settings(BaseSettings):
     mqtts_port: int = 8883
     mqtts_public_key: str = "./cert.pem"
     mqtts_private_key: str = "./pkey.pem"
-    http_port: int = 5000
+    http_port: int = 443
     app_root: str = ""

--- a/static/package.json
+++ b/static/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "bootstrap": "^4.5.3",
+    "create-react-app": "^4.0.0",
     "node-sass": "^4.14.1",
     "prop-types": "^15.7.2",
     "rc-slider": "^9.5.4",
@@ -18,14 +19,14 @@
     "react-redux": "^7.2.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "3.4.3",
+    "react-scripts": "^4.0.0",
     "redux": "^4.0.5",
     "redux-api-middleware": "^3.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export HTTPS=true&&PORT=3000 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -45,5 +46,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:5000"
+  "proxy": "https://localhost"
 }


### PR DESCRIPTION
Both react as well as uvicorn support HTTPS. This eliminates the need for an SSL reverse proxy outside of the container.