### PR TITLE
Update stored firmware version on checkin

### DIFF
--- a/feeder/api/routers/kronos.py
+++ b/feeder/api/routers/kronos.py
@@ -42,6 +42,9 @@ async def add_gateway(gateway: NewGateway):
         content = {"hid": gateway_hid, "message": "OK"}
     except IntegrityError:
         logger.debug("Gateway (%s) already registered!", gateway_hid)
+        await KronosGateways.update(
+            gateway_hid=gateway_hid, firmware_version=gateway.softwareVersion
+        )
         content = {"hid": gateway_hid, "message": "gateway is already registered"}
         return JSONResponse(content=content, headers=kronos_headers)
 
@@ -66,6 +69,9 @@ async def register_feeder(device: NewDevice):
         await KronosDevices.create(**device.dict())
     except IntegrityError:
         logger.debug("Device (%s) already registered!", device_hid)
+        await KronosDevices.update(
+            device_hid=device_hid, firmware_version=device.softwareVersion
+        )
 
     content = {
         "hid": device_hid,

--- a/feeder/database/models.py
+++ b/feeder/database/models.py
@@ -85,6 +85,21 @@ class KronosGateways:
             results = await db.fetch_all(query)
         return results[0]
 
+    @classmethod
+    async def update(cls, *, gateway_hid: str, firmware_version: str):
+        query = (
+            gateways.update()
+            .where(gateways.c.hid == gateway_hid)
+            .values(softwareVersion=firmware_version)
+        )
+        await db.execute(query)
+        device_query = (
+            devices.update()
+            .where(devices.c.gatewayHid == gateway_hid)
+            .values(softwareVersion=firmware_version)
+        )
+        await db.execute(device_query)
+
 
 devices = Table(
     "kronos_device",
@@ -167,6 +182,7 @@ class KronosDevices:
         front_button: bool = None,
         recipe_id: int = None,
         black: bool = None,
+        firmware_version: str = None,
     ):
         values = {}
         if name is not None:
@@ -179,6 +195,8 @@ class KronosDevices:
             values["currentRecipe"] = recipe_id
         if black is not None:
             values["black"] = black
+        if firmware_version is not None:
+            values["softwareVersion"] = firmware_version
         query = devices.update().where(devices.c.hid == device_hid).values(**values)
         results = await db.execute(query)
         return results

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -92,6 +92,27 @@ async def test_get_or_insert_gateway():
 
 
 @pytest.mark.asyncio
+async def test_set_gateway_firmware(with_registered_device: None):
+    from feeder.database.models import KronosGateways, KronosDevices
+
+    device = await KronosDevices.get(gateway_hid=SAMPLE_GATEWAY_HID)
+    gateway = await KronosGateways.get(gateway_hid=SAMPLE_GATEWAY_HID)
+
+    assert gateway[0].softwareVersion != "2.9.0"
+    assert device[0].softwareVersion != "2.9.0"
+
+    await KronosGateways.update(
+        gateway_hid=SAMPLE_GATEWAY_HID, firmware_version="2.9.0"
+    )
+
+    device = await KronosDevices.get(gateway_hid=SAMPLE_GATEWAY_HID)
+    gateway = await KronosGateways.get(gateway_hid=SAMPLE_GATEWAY_HID)
+
+    assert gateway[0].softwareVersion == "2.9.0"
+    assert device[0].softwareVersion == "2.9.0"
+
+
+@pytest.mark.asyncio
 async def test_get_device_parameters(with_registered_device: None):
     from feeder.database.models import KronosDevices
 
@@ -197,6 +218,7 @@ async def test_update_device_single_call(with_registered_device: None):
         front_button=False,
         recipe_id=1,
         black=True,
+        firmware_version="2.9.0",
     )
 
     device = await KronosDevices.get(device_hid=SAMPLE_DEVICE_HID)
@@ -205,6 +227,7 @@ async def test_update_device_single_call(with_registered_device: None):
     assert device[0][10] is False
     assert device[0][11] == 1
     assert device[0][12] is True
+    assert device[0].softwareVersion == "2.9.0"
 
 
 @pytest.mark.asyncio
@@ -238,6 +261,10 @@ async def test_update_device_multiple_call(with_registered_device: None):
     assert rows_updated == 1
     rows_updated = await KronosDevices.update(device_hid=SAMPLE_DEVICE_HID, black=True)
     assert rows_updated == 1
+    rows_updated = await KronosDevices.update(
+        device_hid=SAMPLE_DEVICE_HID, firmware_version="2.9.0"
+    )
+    assert rows_updated == 1
 
     device = await KronosDevices.get(device_hid=SAMPLE_DEVICE_HID)
     assert device[0][1] == "testing"
@@ -245,6 +272,7 @@ async def test_update_device_multiple_call(with_registered_device: None):
     assert device[0][10] is False
     assert device[0][11] == 1
     assert device[0][12] is True
+    assert device[0].softwareVersion == "2.9.0"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
We are disregarding potentially new information from feeders that are registering themselves and checking in.