### PR TITLE
Stop history pagination from unbounded horizontal growth

### DIFF
--- a/static/src/components/FeedHistoryTable.js
+++ b/static/src/components/FeedHistoryTable.js
@@ -30,14 +30,7 @@ export const FeedHistoryTableComponent = function (props) {
             </tr>
     )
 
-    let pageNumbers = []
-    for (let number = 1; number <= props.totalPages; number++) {
-        pageNumbers.push(
-            <Pagination.Item key={number} active={number === props.pageNumber} onClick={() => props.changePage(number)}>
-                {number}
-            </Pagination.Item>
-        );
-    }
+    let pageNumbers = <Pagination.Item>Page {props.pageNumber} / {props.totalPages}</Pagination.Item>
 
     const feederDropdownItems = props.feeders.map(
         (feeder) => <Dropdown.Item eventKey={feeder.hid}>{feeder.name}</Dropdown.Item>


### PR DESCRIPTION
As feed history grew, so did our pagination... 😬 

![Markup on 2021-02-11 at 17:48:16](https://user-images.githubusercontent.com/8651166/107713729-7f7eb480-6c91-11eb-8865-b8716252a2a6.png)

I fixed that by simplifying how we render the page count.
![Markup on 2021-02-11 at 17:48:35](https://user-images.githubusercontent.com/8651166/107713734-81487800-6c91-11eb-97b4-78562aec154b.png)
