### PR TITLE
Dramatically reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,6 @@ RUN npm install
 RUN PUBLIC_URL=/{{build_path}} npm run build
 
 FROM python:3.8-alpine3.12
-RUN apk add --no-cache --virtual .build-deps \
-        build-base \
-        libffi-dev \
-        openssl-dev \
-        py3-pip \
-        python3-dev \
-        git
-RUN python -m pip install --upgrade pip
-RUN pip install poetry cryptography==3.3.2
 WORKDIR /tmp
 COPY poetry.lock ./
 COPY pyproject.toml ./
@@ -23,8 +14,19 @@ COPY feeder/ ./feeder
 COPY --from=frontend-build /tmp/build ./static/build
 COPY alembic.ini ./
 COPY README.md ./
-RUN poetry install -v --no-dev
-RUN apk del .build-deps
+RUN apk add --no-cache --virtual .build-deps \
+        build-base \
+        libffi-dev \
+        openssl-dev \
+        py3-pip \
+        python3-dev \
+        git \
+    && python -m pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir poetry cryptography==3.3.2 \
+    && poetry config virtualenvs.create false \
+    && poetry config experimental.new-installer false \
+    && poetry install --no-dev --no-interaction --no-ansi \
+    && apk del .build-deps
 CMD poetry run alembic upgrade head && poetry run python -m feeder
 EXPOSE 1883/tcp
 EXPOSE 5000/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apk add --no-cache --virtual .build-deps \
     && poetry config virtualenvs.create false \
     && poetry config experimental.new-installer false \
     && poetry install --no-dev --no-interaction --no-ansi \
-    && apk del .build-deps
+    && apk del .build-deps \
+    && rm -rf ~/.cache
 CMD poetry run alembic upgrade head && poetry run python -m feeder
 EXPOSE 1883/tcp
 EXPOSE 5000/tcp


### PR DESCRIPTION
I put the container on a combination of Jenny Craig, Weight Watchers, and Atkins. I am happy to report another success story of the container-combo diet.

Before:
```bash
petnet-feeder-service on  master on 🐳 v20.10.2 via 🐍 petnet
➜ docker image ls --format "{{ .Size }}" feedernet:1.0
483MB
```

After:
```bash
petnet-feeder-service on  docker-image-size on 🐳 v20.10.2 via 🐍 petnet took 2m 12s 
➜ docker image ls --format "{{ .Size }}" feedernet:1.0  
99.9MB
```
