### PR TITLE
enable ability to use external mqtt

### DIFF
--- a/feeder/config.py
+++ b/feeder/config.py
@@ -38,10 +38,14 @@ class Settings(BaseSettings):
     app_id: str = "38973487e8241ea4483e88ef8ca7934c8663dc25"
     debug: bool = False
     database_path: str = "./data.db"
+    mqtt_scheme: str = "mqtt"
+    mqtt_host: str = "localhost"
     mqtt_port: int = 1883
+    mqtt_username: str = ""
+    mqtt_password: str = ""
     mqtts_port: int = 8883
     mqtts_public_key: str = "./cert.pem"
     mqtts_private_key: str = "./pkey.pem"
     http_port: int = 5000
     app_root: str = ""
-    domain: str = ""  # Added as SAN to self-signed cert
+    domain: str = ""

--- a/feeder/main.py
+++ b/feeder/main.py
@@ -52,7 +52,13 @@ async def render_frontend(full_path: str, request: Request):
 def create_application() -> FastAPI:
     async_loop = asyncio.get_event_loop()
     async_loop.set_exception_handler(handle_exception)
-    client = FeederClient()
+    client = FeederClient(
+        scheme=settings.mqtt_scheme,
+        host=settings.mqtt_host,
+        port=settings.mqtt_port,
+        username=settings.mqtt_username or None,
+        password=settings.mqtt_password or None,
+    )
     broker = FeederBroker()
 
     mqtt_enabled_routers = [feeder, pet]


### PR DESCRIPTION
This is a "small" modification. I was originally going to just add webhook capability but decided this would be a less destructive way to handle it.

I've not tested this yet (working on getting it built and will validate).