### PR TITLE
CI with GITHUB_TOKEN instead of PAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.TEDDER_CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push latest
         uses: docker/build-push-action@v2


### PR DESCRIPTION
This problem was fixed a while ago, so we do not need to use a PAT anymore.