### PR TITLE
Take out build_path template until it works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY static/package*.json ./
 COPY static/src ./src
 COPY static/public ./public
 RUN npm install
-RUN PUBLIC_URL=/{{build_path}} npm run build
+RUN PUBLIC_URL=/build npm run build
 
 FROM python:3.9.5-alpine3.12
 WORKDIR /tmp

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are planning on solely developing for the backend, you can build a static
 
 ```
 cd static
-PUBLIC_URL=/{{build_path}} npm run build
+PUBLIC_URL=/build npm run build
 ```
 
 Otherwise, in a different shell, run the Webpack development server:

--- a/feeder/main.py
+++ b/feeder/main.py
@@ -33,14 +33,10 @@ async def render_frontend(full_path: str, request: Request):
         raise HTTPException(status_code=404)
 
     if frontend.exists():
-        build_path = "build"
-        if settings.app_root:
-            build_path = f"{settings.app_root[1:]}/build"
         return frontend_template.TemplateResponse(
             "index.html",
             {
                 "request": request,
-                "build_path": build_path,
                 "root_path": settings.app_root,
             },
         )


### PR DESCRIPTION
Since it is breaking the docker container, take out the build path value
until we can fix the templating engine to work with all of the javascript
files.

Possibly related to issue #130