### PR TITLE
Use application/json content-type where appropriate

### DIFF
--- a/static/src/actions/createPet.js
+++ b/static/src/actions/createPet.js
@@ -24,6 +24,7 @@ export const createPetAction = (
   const meta = {
     method: "POST",
     endpoint: `${PET_API_BASE}`,
+    headers: { "Content-Type": "application/json" },
     body,
   };
   return createAction({
@@ -35,6 +36,7 @@ export const createPetAction = (
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };

--- a/static/src/actions/createPetSchedule.js
+++ b/static/src/actions/createPetSchedule.js
@@ -17,6 +17,7 @@ export const createPetScheduleAction = (
   const meta = {
     method: "POST",
     endpoint: `${PET_API_BASE}/${petId}/schedule`,
+    headers: { "Content-Type": "application/json" },
     body,
     petId,
   };
@@ -29,6 +30,7 @@ export const createPetScheduleAction = (
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };

--- a/static/src/actions/modifyFeeder.js
+++ b/static/src/actions/modifyFeeder.js
@@ -21,6 +21,7 @@ export const modifyFeederAction = (
   const meta = {
     method: "PUT",
     endpoint: `${FEEDER_API_BASE}/${deviceId}`,
+    headers: { "Content-Type": "application/json" },
     body,
   };
   return createAction({
@@ -32,6 +33,7 @@ export const modifyFeederAction = (
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };

--- a/static/src/actions/modifyPet.js
+++ b/static/src/actions/modifyPet.js
@@ -25,6 +25,7 @@ export const modifyPetAction = (
   const meta = {
     method: "PUT",
     endpoint: `${PET_API_BASE}/${pet_id}`,
+    headers: { "Content-Type": "application/json" },
     body,
   };
   return createAction({
@@ -36,6 +37,7 @@ export const modifyPetAction = (
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };

--- a/static/src/actions/setHopperLevel.js
+++ b/static/src/actions/setHopperLevel.js
@@ -9,6 +9,7 @@ export const setHopperLevelAction = (deviceId, level) => {
   const meta = {
     method: "POST",
     endpoint: `${FEEDER_API_BASE}/${deviceId}/hopper`,
+    headers: { "Content-Type": "application/json" },
     body,
   };
   return createAction({
@@ -20,6 +21,7 @@ export const setHopperLevelAction = (deviceId, level) => {
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };

--- a/static/src/actions/updatePetSchedule.js
+++ b/static/src/actions/updatePetSchedule.js
@@ -20,6 +20,7 @@ export const updatePetScheduleAction = (
   const meta = {
     method: "PUT",
     endpoint: `${PET_API_BASE}/${petId}/schedule/${eventId}`,
+    headers: { "Content-Type": "application/json" },
     body,
     petId,
   };
@@ -32,6 +33,7 @@ export const updatePetScheduleAction = (
     ],
     method: meta.method,
     credentials: "include",
+    headers: meta.headers,
     body,
   });
 };


### PR DESCRIPTION
Any PUT or POST that submits JSON data should use the application/json
MIME type so that the server can properly interpret it.

May help with issues reported on #130