### PR TITLE
Use milliseconds instead of microseconds

### DIFF
--- a/feeder/database/alembic/versions/1029aaae7a08_migrate_to_milliseconds.py
+++ b/feeder/database/alembic/versions/1029aaae7a08_migrate_to_milliseconds.py
@@ -1,0 +1,41 @@
+"""migrate to milliseconds
+
+Revision ID: 1029aaae7a08
+Revises: 593d4ecb0616
+Create Date: 2022-05-01 09:09:40.989955
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "1029aaae7a08"
+down_revision = "593d4ecb0616"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        "UPDATE feed_event SET start_time = start_time / 1000, end_time = end_time / 1000, timestamp = timestamp / 1000"
+    )
+    op.execute(
+        "UPDATE kronos_device SET discoveredAt = discoveredAt / 1000, lastPingedAt = lastPingedAt / 1000"
+    )
+    op.execute("UPDATE kronos_device_sensors SET timestamp = timestamp / 1000")
+    op.execute("UPDATE hopper_references SET timestamp = timestamp / 1000")
+    op.execute("UPDATE kronos_gateway SET discoveredAt = discoveredAt / 1000")
+    op.execute("UPDATE pets SET birthday = birthday / 1000")
+
+
+def downgrade():
+    op.execute(
+        "UPDATE feed_event SET start_time = start_time * 1000, end_time = end_time * 1000, timestamp = timestamp * 1000"
+    )
+    op.execute(
+        "UPDATE kronos_device SET discoveredAt = discoveredAt * 1000, lastPingedAt = lastPingedAt * 1000"
+    )
+    op.execute("UPDATE kronos_device_sensors SET timestamp = timestamp * 1000")
+    op.execute("UPDATE hopper_references SET timestamp = timestamp * 1000")
+    op.execute("UPDATE kronos_gateway SET discoveredAt = discoveredAt * 1000")
+    op.execute("UPDATE pets SET birthday = birthday * 1000")

--- a/feeder/database/models.py
+++ b/feeder/database/models.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.sql.expression import literal
 
 from feeder.util.feeder import generate_api_key, generate_feeder_hid
-from feeder.util import get_current_timestamp
+from feeder.util import MILLIS_PER_SEC, get_current_timestamp
 from feeder.database.session import db, metadata
 
 logger = logging.getLogger(__name__)
@@ -370,8 +370,8 @@ class FeedingResult:
         query = feeding_event.insert().values(
             device_hid=device_hid,
             timestamp=get_current_timestamp(),
-            start_time=start_time * 1000000,
-            end_time=end_time * 1000000,
+            start_time=start_time * MILLIS_PER_SEC,
+            end_time=end_time * MILLIS_PER_SEC,
             pour=pour,
             full=full,
             grams_expected=grams_expected,
@@ -400,8 +400,8 @@ class FeedingResult:
     @staticmethod
     async def dispensed_at(device_id: str, timestamp: int, window_minutes: int = 5):
         offset = (
-            window_minutes * 60 * 1000000
-        )  # minute -> second (60) -> microsec (1000000)
+            window_minutes * 60 * 1000
+        )  # minute -> second (60) -> milliseconds (1000)
         query = (
             feeding_event.select()
             .where(feeding_event.c.device_hid == device_id)

--- a/feeder/util/__init__.py
+++ b/feeder/util/__init__.py
@@ -3,14 +3,14 @@ from datetime import datetime, time
 
 import pytz
 
-MICROSEC_IN_SEC = 1000000
+MILLIS_PER_SEC = 1000
 
 logger = logging.getLogger()
 
 
 def get_current_timestamp() -> int:
     now = datetime.timestamp(datetime.now())
-    return int(now * MICROSEC_IN_SEC)
+    return int(now * MILLIS_PER_SEC)
 
 
 def get_relative_timestamp(seconds_since_midnight: int, timezone: str) -> int:
@@ -22,4 +22,4 @@ def get_relative_timestamp(seconds_since_midnight: int, timezone: str) -> int:
 
     midnight = datetime.combine(datetime.now(zone), time.min)
     timestamp = datetime.timestamp(midnight) + seconds_since_midnight
-    return int(timestamp * MICROSEC_IN_SEC)
+    return int(timestamp * MILLIS_PER_SEC)

--- a/static/src/util/index.js
+++ b/static/src/util/index.js
@@ -3,7 +3,7 @@ export function formatUnixTimestamp(
   showDate = true,
   showTime = true
 ) {
-  const date = new Date(timeFromEpoch / 1000);
+  const date = new Date(timeFromEpoch);
   let formatDate = "";
   let formatTime = "";
 
@@ -19,9 +19,8 @@ export function formatUnixTimestamp(
 }
 
 export function isStale(timeFromEpoch, staleSeconds = 120) {
-  const ping = timeFromEpoch / 1000;
   const now = new Date().getTime();
-  return now - ping > staleSeconds * 1000;
+  return now - timeFromEpoch > staleSeconds * 1000;
 }
 
 export function getRootPath() {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ async def with_sample_feed(with_registered_device: None) -> None:
     from feeder.database.models import FeedingResult
     from feeder.util import get_relative_timestamp
 
-    feed_time = int(get_relative_timestamp(3600, "") / 1000000)
+    feed_time = int(get_relative_timestamp(3600, "") / 1000)
     await FeedingResult.report(
         device_hid=SAMPLE_DEVICE_HID,
         start_time=feed_time,

--- a/tests/test_database_models.py
+++ b/tests/test_database_models.py
@@ -192,7 +192,7 @@ async def test_ping_device(with_registered_device: None):
         device_hid=SAMPLE_DEVICE_HID, gateway_hid=SAMPLE_GATEWAY_HID
     )
     device_with_new_ping = await KronosDevices.get(device_hid=SAMPLE_DEVICE_HID)
-    assert device_with_new_ping[0][8] > device_with_ping[0][8]
+    assert device_with_new_ping[0][8] >= device_with_ping[0][8]
 
 
 @pytest.mark.asyncio
@@ -384,8 +384,8 @@ async def test_create_feed_result(with_registered_device: None):
 
     rows_modified = await FeedingResult.report(
         device_hid=SAMPLE_DEVICE_HID,
-        start_time=1,
-        end_time=2,
+        start_time=1651370724,
+        end_time=1651370727,
         pour=3,
         full=4,
         grams_expected=5,
@@ -402,6 +402,12 @@ async def test_create_feed_result(with_registered_device: None):
     assert len(await FeedingResult.get(device_hid=SAMPLE_DEVICE_HID)) == 1
     assert await FeedingResult.count() == 1
     assert await FeedingResult.count(device_hid=SAMPLE_DEVICE_HID) == 1
+    assert (
+        await FeedingResult.dispensed_at(
+            device_id=SAMPLE_DEVICE_HID, timestamp=1651370700000
+        )
+        is not None
+    )
 
 
 @pytest.mark.asyncio
@@ -709,7 +715,7 @@ async def test_set_hopper_level(with_registered_device: None):
     for index in range(100):
         row_mod = await FeedingResult.report(
             device_hid=SAMPLE_DEVICE_HID,
-            start_time=int(get_current_timestamp() / 1000000) + index,
+            start_time=int(get_current_timestamp() / 1000) + index,
             end_time=2,
             pour=3,
             full=4,

--- a/tests/test_routes/test_pet.py
+++ b/tests/test_routes/test_pet.py
@@ -5,7 +5,7 @@ SAMPLE_PET = {
     "image": "base64data",
     "animal_type": "cat",
     "weight": 3628.74,
-    "birthday": 1483164000000000,
+    "birthday": 1483164000000,
     "activity_level": 5,
 }
 

--- a/tests/test_utils/test_main.py
+++ b/tests/test_utils/test_main.py
@@ -6,7 +6,7 @@ def test_current_timestamp():
 
     timestamp = get_current_timestamp()
     assert isinstance(timestamp, int)
-    assert int(math.log10(timestamp)) + 1 == 16
+    assert int(math.log10(timestamp)) + 1 == 13
 
 
 def test_offset_timestamp():
@@ -14,11 +14,11 @@ def test_offset_timestamp():
 
     timestamp = get_relative_timestamp(0, "UTC")
     assert isinstance(timestamp, int)
-    assert int(math.log10(timestamp)) + 1 == 16
+    assert int(math.log10(timestamp)) + 1 == 13
 
     timestamp_offset = get_relative_timestamp(3600, "UTC")
     assert isinstance(timestamp_offset, int)
-    assert int(math.log10(timestamp)) + 1 == 16
+    assert int(math.log10(timestamp)) + 1 == 13
 
     assert timestamp < timestamp_offset
 
@@ -28,10 +28,10 @@ def test_offset_timestamp_invalid_timezone():
 
     timestamp = get_relative_timestamp(0, "notarealzone")
     assert isinstance(timestamp, int)
-    assert int(math.log10(timestamp)) + 1 == 16
+    assert int(math.log10(timestamp)) + 1 == 13
 
     timestamp_offset = get_relative_timestamp(3600, "notarealzone")
     assert isinstance(timestamp_offset, int)
-    assert int(math.log10(timestamp)) + 1 == 16
+    assert int(math.log10(timestamp)) + 1 == 13
 
     assert timestamp < timestamp_offset

--- a/tests/test_utils/test_mqtt_client.py
+++ b/tests/test_utils/test_mqtt_client.py
@@ -112,8 +112,8 @@ async def test_commit_telem_feed_result(with_registered_device: None):
 
     results = await FeedingResult.get(device_hid=SAMPLE_DEVICE_HID)
     assert results[0].device_hid == SAMPLE_DEVICE_HID
-    assert results[0].start_time == 1000000
-    assert results[0].end_time == 2000000
+    assert results[0].start_time == 1000
+    assert results[0].end_time == 2000
     assert results[0].pour == 3
     assert results[0].full == 4
     assert results[0].grams_expected == 5


### PR DESCRIPTION
The Alchemy adapter apparently doesn't like the microseconds timestamp because it overflows 64-bit signed integer values. When converting to milliseconds it seems to be more natural for all languages.

This seems to fix the missing feedings in the UI.

<img width="1328" alt="Screen Shot 2022-04-30 at 8 50 10 PM" src="https://user-images.githubusercontent.com/50407/166131483-9239ab4c-b683-4e1c-ac7e-70f3e1f44d70.png">

Items still to-do:

- [x] Add migration for database from microseconds to milliseconds