### PR TITLE
Allow publish to telemetry topic

### DIFF
--- a/feeder/util/mqtt/topic.py
+++ b/feeder/util/mqtt/topic.py
@@ -1,6 +1,7 @@
 import re
 import logging
 
+from amqtt.broker import Action
 from amqtt.plugins.topic_checking import BaseTopicPlugin
 from feeder.util.mqtt.authentication import local_username
 
@@ -9,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 class PetnetTopicPlugin(BaseTopicPlugin):
     feeder_sub_topic_regex = re.compile(r"krs/(api|cmd)/stg/(?P<gateway_id>.*)$")
+    feeder_pub_topic_regex = re.compile(r"krs.(api|tel).gts.(?P<gateway_id>.*)$")
     username_regex = re.compile(r"^/pegasus:(?P<gateway_id>.*)$")
 
     async def topic_filtering(
@@ -19,8 +21,11 @@ class PetnetTopicPlugin(BaseTopicPlugin):
             return False
 
         session = kwargs.get("session", None)
+        action = kwargs.get("action", None)
         topic = kwargs.get("topic", None)
-        logger.debug("username: %s, topic: %s", session.username, topic)
+        logger.debug(
+            "username: %s, action: %s, topic: %s", session.username, action, topic
+        )
 
         if session.username == local_username:
             return True
@@ -34,13 +39,22 @@ class PetnetTopicPlugin(BaseTopicPlugin):
 
         gateway_id = user_match.group("gateway_id")
 
-        topic_match = self.feeder_sub_topic_regex.match(topic)
+        if action == Action.subscribe:
+            topic_match = self.feeder_sub_topic_regex.match(topic)
+        elif action == Action.publish:
+            topic_match = self.feeder_pub_topic_regex.match(topic)
+        else:
+            logger.warning("Unhandled action %s", action)
+            return False
+
         if not topic_match:
             return False
 
         target_id = topic_match.group("gateway_id")
         if gateway_id != target_id:
-            logger.warning("Gateway %s tried to subscribe to %s", gateway_id, target_id)
+            logger.warning(
+                "Gateway %s tried to %s to %s", gateway_id, action, target_id
+            )
             return False
 
         return True


### PR DESCRIPTION
The new version of the MQTT broker we use also filters published topics from clients,
so we need to accept the published telemetry data from the gateway.